### PR TITLE
Fix/input and form typescirpt error

### DIFF
--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -4,13 +4,13 @@ import { ResponsiveProp } from "../../types";
 
 interface DeprecatedRenderParams {
   state: {
-    values: Record<string, any>;
-    errors: Record<string, any>;
+    values: any;
+    errors: any;
   };
   validateField: (name: string) => void;
   submitForm: () => void;
-  setValues: (vals: Record<string, any>) => void;
-  setErrors: (errors: Record<string, any>) => void;
+  setValues: (vals: any) => void;
+  setErrors: (errors: any) => void;
   resetForm: () => void;
 }
 
@@ -21,8 +21,8 @@ interface DeprecatedSubmitParams {
 }
 
 export type DeprecatedFormProps = {
-  initialValues: Record<string, any>;
-  initialErrors?: Record<string, any>;
+  initialValues: any;
+  initialErrors?: any;
   onSubmit?: (params: DeprecatedSubmitParams) => void;
   debug?: boolean;
   testId?: string;

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -15,9 +15,9 @@ interface DeprecatedRenderParams {
 }
 
 interface DeprecatedSubmitParams {
-  errors: Record<string, any>;
-  values: Record<string, any>;
-  setErrors: (errors: Record<string, any>) => void;
+  errors: any;
+  values: any;
+  setErrors: (errors: any) => any;
 }
 
 export type DeprecatedFormProps = {

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -22,7 +22,7 @@ interface DeprecatedSubmitParams {
 
 export type DeprecatedFormProps = {
   initialValues: Record<string, any>;
-  intialErrors?: Record<string, any>;
+  initialErrors?: Record<string, any>;
   onSubmit?: (params: DeprecatedSubmitParams) => void;
   debug?: boolean;
   testId?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export type ComponentWithStaticProperties<
 > =
   | (React.ForwardRefExoticComponent<Props & React.RefAttributes<any>> &
       Properties)
-  | (React.Component<Props> & Properties);
+  | (React.ComponentType<Props> & Properties);
 
 export type ValidationError = string | string[] | Record<string, string> | null;
 


### PR DESCRIPTION
Fix the following errors:
## Input
```
JSX element type 'Input' does not have any construct or call signatures.
```

That comes up because `React.Component` is not the correct type and should be `React.ComponentType` 

## Form
```
Type 'DeprecatedSubmitParams' is not assignable to type '{ errors: IErrors; values: FormValues; setErrors: () => void; }'.
```

That errors and other similar errors come up because the types on the Deprecated form are too restrictive and expect exactly the same type. For now I have set those types to be any.