### PR TITLE
Fix: Only emit types that are exported via index.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "rimraf": "3.0.2",
     "rollup": "2.46.0",
     "rollup-plugin-delete": "2.0.0",
+    "rollup-plugin-dts": "3.0.2",
     "rollup-plugin-peer-deps-external": "2.2.4",
     "rollup-plugin-typescript2": "0.30.0",
     "semver": "7.3.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import { babel } from "@rollup/plugin-babel";
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
+import dts from "rollup-plugin-dts";
 
 export default [
   {
@@ -24,8 +25,14 @@ export default [
       commonjs(),
       typescript({
         include: ["src/*.js", "src/**/*.js", "src/*.ts(x)?", "src/**/*.ts(x)?"],
+        useTsconfigDeclarationDir: true,
       }),
     ],
     external: Object.keys(pkg.peerDependencies || {}),
+  },
+  {
+    input: "./dist/dts/index.d.ts",
+    output: [{ file: "dist/index.d.ts", format: "es" }],
+    plugins: [dts()],
   },
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "jsx": "react-jsx",
     "declaration": true,
     "outDir": "./dist",
-    "noEmit": true,
+    "emitDeclarationOnly": true,
     "isolatedModules": true,
     "strict": true,
     "noImplicitAny": true,
@@ -18,6 +18,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "declarationDir": "./dist/dts",
     "jsxImportSource": "@emotion/react"
   },
   "include": ["src/**/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7289,6 +7289,15 @@ rollup-plugin-delete@2.0.0:
   dependencies:
     del "^5.1.0"
 
+rollup-plugin-dts@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-3.0.2.tgz#2b628d88f864d271d6eaec2e4c2a60ae4e944c5c"
+  integrity sha512-hswlsdWu/x7k5pXzaLP6OvKRKcx8Bzprksz9i9mUe72zvt8LvqAb/AZpzs6FkLgmyRaN8B6rUQOVtzA3yEt9Yw==
+  dependencies:
+    magic-string "^0.25.7"
+  optionalDependencies:
+    "@babel/code-frame" "^7.12.13"
+
 rollup-plugin-peer-deps-external@2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz#8a420bbfd6dccc30aeb68c9bf57011f2f109570d"


### PR DESCRIPTION
Currently all of basis types are exposed via `dist` and are suggested by vscode. This PR limits the exposed types to the ones exported via `src/index.ts`

More info: https://medium.com/@martin_hotell/typescript-library-tips-rollup-your-types-995153cc81c7