### PR TITLE
Fix: Revert Typescript changes breaking JS comps

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,9 @@ import { babel } from "@rollup/plugin-babel";
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
-import dts from "rollup-plugin-dts";
+// commented out because breaking js components.
+// revert when js components have been converted to TS
+// import dts from "rollup-plugin-dts";
 
 export default [
   {
@@ -25,14 +27,14 @@ export default [
       commonjs(),
       typescript({
         include: ["src/*.js", "src/**/*.js", "src/*.ts(x)?", "src/**/*.ts(x)?"],
-        useTsconfigDeclarationDir: true,
+        // useTsconfigDeclarationDir: true,
       }),
     ],
     external: Object.keys(pkg.peerDependencies || {}),
   },
-  {
-    input: "./dist/dts/index.d.ts",
-    output: [{ file: "dist/index.d.ts", format: "es" }],
-    plugins: [dts()],
-  },
+  // {
+  //   input: "./dist/dts/index.d.ts",
+  //   output: [{ file: "dist/index.d.ts", format: "es" }],
+  //   plugins: [dts()],
+  // },
 ];


### PR DESCRIPTION
Typescript fix resulted in broken types for javascript components. This is primarily because the responsive proptypes which are not being inferred by typescript.

This can be undone once the components are converted to TS